### PR TITLE
build: restrict acceptable PyJWT versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ cwltool>=1.0.20181201184214
 future>=0.16.0
 requests>=2.18.2
 py-tes>=0.3.0
-PyJWT>=1.6.4
+PyJWT>=1.6.4,<2.0.0
 typing_extensions


### PR DESCRIPTION
API of PyJWT `.decode` method changed in v2.0.0 and upwards.